### PR TITLE
messaging_referrals events (m.me links) supported

### DIFF
--- a/fbmq/fbmq.py
+++ b/fbmq/fbmq.py
@@ -61,6 +61,10 @@ class Event(object):
         return self.messaging.get("postback", {})
 
     @property
+    def postback_referral(self):
+        return self.messaging.get("postback", {}).get("referral", {})
+
+    @property
     def optin(self):
         return self.messaging.get("optin", {})
 
@@ -117,6 +121,10 @@ class Event(object):
         return 'postback' in self.messaging
 
     @property
+    def is_postback_referral(self):
+        return self.is_postback and 'referral' in self.postback
+
+    @property
     def is_read(self):
         return 'read' in self.messaging
 
@@ -143,6 +151,10 @@ class Event(object):
     @property
     def referral_ref(self):
         return self.messaging.get("referral", {}).get("ref", '')
+
+    @property
+    def postback_referral_ref(self):
+        return self.messaging.get("postback", {}).get("referral", {}).get("ref", '')
 
 
 class Page(object):

--- a/fbmq/fbmq.py
+++ b/fbmq/fbmq.py
@@ -77,6 +77,10 @@ class Event(object):
         return self.messaging.get("read", {})
 
     @property
+    def referral(self):
+        return self.messaging.get("referral", {})
+
+    @property
     def message_mid(self):
         return self.messaging.get("message", {}).get("mid", None)
 
@@ -121,6 +125,10 @@ class Event(object):
         return 'account_linking' in self.messaging
 
     @property
+    def is_referral(self):
+        return 'referral' in self.messaging
+
+    @property
     def is_quick_reply(self):
         return self.messaging.get("message", {}).get("quick_reply", None) is not None
 
@@ -132,6 +140,10 @@ class Event(object):
     def postback_payload(self):
         return self.messaging.get("postback", {}).get("payload", '')
 
+    @property
+    def referral_ref(self):
+        return self.messaging.get("referral", {}).get("ref", '')
+
 
 class Page(object):
     def __init__(self, page_access_token, **options):
@@ -140,7 +152,7 @@ class Page(object):
         self._page_id = None
         self._page_name = None
 
-    # webhook_handlers contains optin, message, echo, delivery, postback, read, account_linking.
+    # webhook_handlers contains optin, message, echo, delivery, postback, read, account_linking, referral.
     # these are only set by decorators
     _webhook_handlers = {}
 
@@ -161,7 +173,7 @@ class Page(object):
             print("there's no %s handler" % name)
 
     def handle_webhook(self, payload, optin=None, message=None, echo=None, delivery=None,
-                       postback=None, read=None, account_linking=None):
+                       postback=None, read=None, account_linking=None, referral=None):
         data = json.loads(payload)
 
         # Make sure this is a page subscription
@@ -200,6 +212,8 @@ class Page(object):
                 self._call_handler('read', read, event)
             elif event.is_account_linking:
                 self._call_handler('account_linking', account_linking, event)
+            elif event.is_referral:
+                self._call_handler('referral', referral, event)
             else:
                 print("Webhook received unknown messagingEvent:", event)
 
@@ -398,6 +412,9 @@ class Page(object):
 
     def handle_account_linking(self, func):
         self._webhook_handlers['account_linking'] = func
+
+    def handle_referral(self, func):
+        self._webhook_handlers['referral'] = func
 
     def after_send(self, func):
         self._after_send = func

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -116,6 +116,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_echo)
             self.assertFalse(event.is_read)
             self.assertFalse(event.is_postback)
+            self.assertFalse(event.is_postback_referral)
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)
@@ -156,6 +157,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_echo)
             self.assertTrue(event.is_read)
             self.assertFalse(event.is_postback)
+            self.assertFalse(event.is_postback_referral)
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)
@@ -197,6 +199,7 @@ class PageTest(unittest.TestCase):
             self.assertTrue(event.is_echo)
             self.assertFalse(event.is_read)
             self.assertFalse(event.is_postback)
+            self.assertFalse(event.is_postback_referral)
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)
@@ -236,6 +239,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_echo)
             self.assertFalse(event.is_read)
             self.assertFalse(event.is_postback)
+            self.assertFalse(event.is_postback_referral)
             self.assertFalse(event.is_optin)
             self.assertTrue(event.is_delivery)
             self.assertFalse(event.is_account_linking)
@@ -275,6 +279,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_echo)
             self.assertFalse(event.is_read)
             self.assertFalse(event.is_postback)
+            self.assertFalse(event.is_postback_referral)
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertTrue(event.is_account_linking)
@@ -314,6 +319,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_echo)
             self.assertFalse(event.is_read)
             self.assertFalse(event.is_postback)
+            self.assertFalse(event.is_postback_referral)
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)
@@ -355,6 +361,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_echo)
             self.assertFalse(event.is_read)
             self.assertTrue(event.is_postback)
+            self.assertFalse(event.is_postback_referral)
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)
@@ -365,6 +372,52 @@ class PageTest(unittest.TestCase):
             self.assertEquals(event.message_text, None)
             self.assertEquals(event.postback_payload, 'DEVELOPED_DEFINED_PAYLOAD')
             self.assertEquals(event.postback_payload, event.postback.get('payload'))
+            counter1()
+
+        self.page.handle_webhook(payload)
+        self.assertEquals(1, counter1.call_count)
+
+        counter2 = mock.MagicMock()
+
+        def handler2(event):
+            counter2()
+
+        self.page.handle_webhook(payload, postback=handler2)
+        self.assertEquals(1, counter2.call_count)
+
+    def test_handle_webhook_postback_referral(self):
+        payload = """
+        {"object":"page","entry":[{"id":"1691462197845448","time":1472028006107,
+        "messaging":[{
+            "sender":{"id":"1134343043305865"},"recipient":{"id":"1691462197845448"},"timestamp":1472028006107,
+            "postback":{"payload":"DEVELOPED_DEFINED_PAYLOAD",
+                        "referral":{"ref":"REFTEST","source":"SHORTLINK","type": "OPEN_THREAD"}}}]
+        }]}
+        """
+        counter1 = mock.MagicMock()
+
+        @self.page.handle_postback
+        def handler1(event):
+            self.assertFalse(event.is_message)
+            self.assertFalse(event.is_text_message)
+            self.assertFalse(event.is_attachment_message)
+            self.assertFalse(event.is_quick_reply)
+            self.assertFalse(event.is_echo)
+            self.assertFalse(event.is_read)
+            self.assertTrue(event.is_postback)
+            self.assertTrue(event.is_postback_referral)
+            self.assertFalse(event.is_optin)
+            self.assertFalse(event.is_delivery)
+            self.assertFalse(event.is_account_linking)
+            self.assertFalse(event.is_referral)
+            self.assertEquals(event.timestamp, 1472028006107)
+            self.assertEquals(event.sender_id, '1134343043305865')
+            self.assertEquals(event.recipient_id, '1691462197845448')
+            self.assertEquals(event.message_text, None)
+            self.assertEquals(event.postback_payload, 'DEVELOPED_DEFINED_PAYLOAD')
+            self.assertEquals(event.postback_payload, event.postback.get('payload'))
+            self.assertEquals(event.postback_referral, event.postback.get('referral'))
+            self.assertEquals(event.postback_referral_ref, 'REFTEST')
             counter1()
 
         self.page.handle_webhook(payload)
@@ -397,6 +450,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_echo)
             self.assertFalse(event.is_read)
             self.assertTrue(event.is_postback)
+            self.assertFalse(event.is_postback_referral)
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)
@@ -447,6 +501,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_echo)
             self.assertFalse(event.is_read)
             self.assertFalse(event.is_postback)
+            self.assertFalse(event.is_postback_referral)
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -119,6 +119,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)
+            self.assertFalse(event.is_referral)
             self.assertEquals(event.timestamp, 1472026867080)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
@@ -158,6 +159,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)
+            self.assertFalse(event.is_referral)
             self.assertEquals(event.timestamp, 1472026869186)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
@@ -198,6 +200,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)
+            self.assertFalse(event.is_referral)
             self.assertEquals(event.timestamp, 1472026868763)
             self.assertEquals(event.sender_id, '1691462197845448')
             self.assertEquals(event.recipient_id, '1134343043305865')
@@ -236,6 +239,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_optin)
             self.assertTrue(event.is_delivery)
             self.assertFalse(event.is_account_linking)
+            self.assertFalse(event.is_referral)
             self.assertEquals(event.timestamp, 0)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
@@ -274,6 +278,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertTrue(event.is_account_linking)
+            self.assertFalse(event.is_referral)
             self.assertEquals(event.timestamp, 1472028542079)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
@@ -289,6 +294,46 @@ class PageTest(unittest.TestCase):
             counter2()
 
         self.page.handle_webhook(payload, account_linking=handler2)
+        self.assertEquals(1, counter2.call_count)
+
+    def test_handle_webhook_referral(self):
+        payload = """
+        {"object":"page","entry":[{"id":"1691462197845448","time":1472028542079,
+        "messaging":[{
+            "sender":{"id":"1134343043305865"},"recipient":{"id":"1691462197845448"},"timestamp":1472028542079,
+            "referral":{"ref":"REFTEST","source":"SHORTLINK","type": "OPEN_THREAD"}}]}]}
+        """
+        counter = mock.MagicMock()
+
+        @self.page.handle_referral
+        def handler1(event):
+            self.assertFalse(event.is_message)
+            self.assertFalse(event.is_text_message)
+            self.assertFalse(event.is_attachment_message)
+            self.assertFalse(event.is_quick_reply)
+            self.assertFalse(event.is_echo)
+            self.assertFalse(event.is_read)
+            self.assertFalse(event.is_postback)
+            self.assertFalse(event.is_optin)
+            self.assertFalse(event.is_delivery)
+            self.assertFalse(event.is_account_linking)
+            self.assertTrue(event.is_referral)
+            self.assertEquals(event.timestamp, 1472028542079)
+            self.assertEquals(event.sender_id, '1134343043305865')
+            self.assertEquals(event.recipient_id, '1691462197845448')
+            self.assertEquals(event.message_text, None)
+            self.assertEqual(event.referral_ref, 'REFTEST')
+            counter()
+
+        self.page.handle_webhook(payload)
+        self.assertEquals(1, counter.call_count)
+
+        counter2 = mock.MagicMock()
+
+        def handler2(event):
+            counter2()
+
+        self.page.handle_webhook(payload, referral=handler2)
         self.assertEquals(1, counter2.call_count)
 
     def test_handle_webhook_postback(self):
@@ -313,6 +358,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)
+            self.assertFalse(event.is_referral)
             self.assertEquals(event.timestamp, 1472028006107)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
@@ -354,6 +400,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)
+            self.assertFalse(event.is_referral)
             self.assertEquals(event.timestamp, 1472028006107)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
@@ -403,6 +450,7 @@ class PageTest(unittest.TestCase):
             self.assertFalse(event.is_optin)
             self.assertFalse(event.is_delivery)
             self.assertFalse(event.is_account_linking)
+            self.assertFalse(event.is_referral)
             self.assertEquals(event.timestamp, 1472028637825)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')


### PR DESCRIPTION
For more information see [1], "2. Existing User Scenario"

[1] https://developers.facebook.com/docs/messenger-platform/referral-params