### PR TITLE
Share Button template supported

### DIFF
--- a/fbmq/template.py
+++ b/fbmq/template.py
@@ -18,7 +18,7 @@ class Buttons(object):
                 if isinstance(item, BaseButton):
                     result.append(item)
                 elif isinstance(item, dict):
-                    if item.get('type') in ['web_url', 'postback', 'phone_number']:
+                    if item.get('type') in ['web_url', 'postback', 'phone_number', 'element_share']:
                         type = item.get('type')
                         title = item.get('title')
                         value = item.get('value', item.get('url', item.get('payload')))
@@ -29,6 +29,8 @@ class Buttons(object):
                             result.append(ButtonPostBack(title=title, payload=value))
                         elif type == 'phone_number':
                             result.append(ButtonPhoneNumber(title=title, payload=value))
+                        elif type == 'element_share':
+                            result.append(ButtonShare())
 
                     else:
                         raise ValueError('Invalid button type')
@@ -62,6 +64,11 @@ class ButtonPhoneNumber(BaseButton):
         self.type = 'phone_number'
         self.title = title
         self.payload = payload
+
+
+class ButtonShare(BaseButton):
+    def __init__(self):
+        self.type = 'element_share'
 
 
 class Generic(object):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -19,17 +19,24 @@ class TemplateTest(unittest.TestCase):
         self.assertEquals('{"payload": "+82108011", "title": "title", "type": "phone_number"}', utils.to_json(btn))
         print(utils.to_json(btn))
 
+    def test_button_share(self):
+        btn = Template.ButtonShare()
+        self.assertEquals('{"type": "element_share"}', utils.to_json(btn))
+        print(utils.to_json(btn))
+
     def test_buttons(self):
         btns1 = Template.Buttons(text="Title", buttons=[
             {'type': 'web_url', 'title': 'title', 'value': 'https://test.com'},
             {'type': 'postback', 'title': 'title', 'value': 'TEST_PAYLOAD'},
             {'type': 'phone_number', 'title': 'title', 'value': '+82108011'},
+            {'type': 'element_share'},
         ])
 
         btns2 = Template.Buttons(text="Title", buttons=[
             Template.ButtonWeb(title="title", url="https://test.com"),
             Template.ButtonPostBack(title="title", payload="TEST_PAYLOAD"),
-            Template.ButtonPhoneNumber(title="title", payload="+82108011")
+            Template.ButtonPhoneNumber(title="title", payload="+82108011"),
+            Template.ButtonShare()
         ])
 
         self.assertEquals(utils.to_json(btns1), utils.to_json(btns2))


### PR DESCRIPTION
For more info, see [1]

[1] https://developers.facebook.com/docs/messenger-platform/send-api-reference/share-button