### PR TITLE
Raise value error to avoid unknown error in server

### DIFF
--- a/fbmq/payload.py
+++ b/fbmq/payload.py
@@ -40,6 +40,8 @@ class Message(object):
     def __init__(self, text=None, attachment=None, quick_replies=None, metadata=None):
         if text is not None and attachment is not None:
             raise ValueError('Please set only one parameter "text" or "attachment"')
+        if not isinstance(quick_replies, list):
+            raise ValueError('quick_replies type must be "list"')
 
         self.text = text
         self.attachment = attachment

--- a/fbmq/payload.py
+++ b/fbmq/payload.py
@@ -40,7 +40,7 @@ class Message(object):
     def __init__(self, text=None, attachment=None, quick_replies=None, metadata=None):
         if text is not None and attachment is not None:
             raise ValueError('Please set only one parameter "text" or "attachment"')
-        if not isinstance(quick_replies, list):
+        if not isinstance(quick_replies, list) and quick_replies is not None:
             raise ValueError('quick_replies type must be "list"')
 
         self.text = text

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -28,6 +28,8 @@ class PayloadTest(unittest.TestCase):
     def test_message(self):
         with self.assertRaises(Exception):
             m = Payload.Message(text="hello", attachment=Attachment.Image('img'))
+        with self.assertRaises(ValueError):
+            m = Payload.Message(text="hello", quick_replies=Payload.QuickReply(title='Yes', payload='PICK_YES'))
 
         m = Payload.Message(text="hello", metadata="METADATA", quick_replies=[{'title': 'Yes', 'payload': 'PICK_YES'}])
         self.assertEquals('{"attachment": null, "metadata": "METADATA", '


### PR DESCRIPTION
When using QuickReply Buttons, it is better to raise type error in advance before making internal server error. I found this issue when I tried to send **one** Quickreply button without list. The fbmq didn't alert me anything but my server failed to build message.