### PR TITLE
 Messenger Profile API adopted 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - pip install mock
   - pip install requests
   - pip install coveralls
+  - pip install responses
 script: nosetests --with-coverage --cover-package=fbmq
 after_success:
   coveralls

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ from distutils.core import setup
 
 
 long_description = ''
+tests_require = ['responses', 'mock']
+
 
 try:
     import pypandoc
@@ -33,5 +35,7 @@ setup(name='fbmq',
       license='MIT',
       packages=['fbmq'],
       install_requires=['requests>=2.0', 'flask'],
+      tests_require=tests_require,
+      extras_require={'test': tests_require},
       keywords='Facebook Messenger Platform Chatbot',
       )


### PR DESCRIPTION
@kimwz It's a pretty big change, so please review it, if possible.

Also, please note the new way of testing outgoing requests: using [httpretty](https://pypi.python.org/pypi/httpretty) by analyzing the JSON which is sent to FB. It seems to be a bit more correct way, as it checks the real output vs Messenger API spec ([1]) and doesn't require intimate knowledge of current implementation.

[1] https://developers.facebook.com/docs/messenger-platform/reference