### PR TITLE
Add tag

### DIFF
--- a/fbmq/fbmq.py
+++ b/fbmq/fbmq.py
@@ -451,7 +451,7 @@ class Page(object):
         return r
 
     def send(self, recipient_id, message, quick_replies=None, metadata=None,
-             notification_type=None, callback=None):
+             notification_type=None, callback=None, tag=None):
         if sys.version_info >= (3, 0):
             text = message if isinstance(message, str) else None
         else:
@@ -464,7 +464,8 @@ class Page(object):
                                           attachment=attachment,
                                           quick_replies=quick_replies,
                                           metadata=metadata),
-                          notification_type=notification_type)
+                          notification_type=notification_type,
+                          tag=tag)
 
         return self._send(payload, callback=callback)
 

--- a/fbmq/payload.py
+++ b/fbmq/payload.py
@@ -2,7 +2,7 @@ from . import utils
 
 
 class Payload(object):
-    def __init__(self, recipient, message=None, sender_action=None, notification_type=None):
+    def __init__(self, recipient, message=None, sender_action=None, notification_type=None, tag=None):
         self.recipient = recipient
         self.message = message
         if sender_action is not None and sender_action not in ['typing_off', 'typing_on', 'mark_seen']:
@@ -15,6 +15,10 @@ class Payload(object):
             raise ValueError('invalid notification_type : it must be one of "REGULAR","SILENT_PUSH","NO_PUSH"')
 
         self.notification_type = notification_type
+        valid_tags = ["PAIRING_UPDATE", "APPLICATION_UPDATE", "ACCOUNT_UPDATE", "PAYMENT_UPDATE", "PERSONAL_FINANCE_UPDATE", "SHIPPING_UPDATE", "RESERVATION_UPDATE", "ISSUE_RESOLUTION", "APPOINTMENT_UPDATE", "GAME_EVENT", "TRANSPORTATION_UPDATE", "FEATURE_FUNCTIONALITY_UPDATE", "TICKET_UPDATE"]
+        if tag and tag not in valid_tags:
+            raise ValueError('invalid tag: it must be one of ' + ', '.join(['"{}"'.format(v) for v in valid_tags]))
+        self.tag = tag
 
     def to_json(self):
         return utils.to_json(self)

--- a/fbmq/payload.py
+++ b/fbmq/payload.py
@@ -15,8 +15,9 @@ class Payload(object):
             raise ValueError('invalid notification_type : it must be one of "REGULAR","SILENT_PUSH","NO_PUSH"')
 
         self.notification_type = notification_type
+
         valid_tags = ["PAIRING_UPDATE", "APPLICATION_UPDATE", "ACCOUNT_UPDATE", "PAYMENT_UPDATE", "PERSONAL_FINANCE_UPDATE", "SHIPPING_UPDATE", "RESERVATION_UPDATE", "ISSUE_RESOLUTION", "APPOINTMENT_UPDATE", "GAME_EVENT", "TRANSPORTATION_UPDATE", "FEATURE_FUNCTIONALITY_UPDATE", "TICKET_UPDATE"]
-        if tag and tag not in valid_tags:
+        if tag is not None and tag not in valid_tags:
             raise ValueError('invalid tag: it must be one of ' + ', '.join(['"{}"'.format(v) for v in valid_tags]))
         self.tag = tag
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -91,7 +91,8 @@ class PageTest(unittest.TestCase):
                                                 '"text": "hello world"},'
                                                 ' "notification_type": null, '
                                                 '"recipient": {"id": 12345}, '
-                                                '"sender_action": null}', callback=1)
+                                                '"sender_action": null, '
+                                                '"tag": null}', callback=1)
 
     def test_typingon(self):
         self.page.typing_on(1004)
@@ -163,7 +164,7 @@ class PageTest(unittest.TestCase):
         def dummy_func():
             pass
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AttributeError):
             self.page.set_webhook_handler("shouldfail", dummy_func)
 
         self.page.set_webhook_handler("message", dummy_func)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -98,19 +98,22 @@ class PageTest(unittest.TestCase):
         self.page.typing_on(1004)
         self.page._send.assert_called_once_with('{"message": null, "notification_type": null, '
                                                 '"recipient": {"id": 1004}, '
-                                                '"sender_action": "typing_on"}')
+                                                '"sender_action": "typing_on", '
+                                                '"tag": null}')
 
     def test_typingoff(self):
         self.page.typing_off(1004)
         self.page._send.assert_called_once_with('{"message": null, "notification_type": null, '
                                                 '"recipient": {"id": 1004}, '
-                                                '"sender_action": "typing_off"}')
+                                                '"sender_action": "typing_off", '
+                                                '"tag": null}')
 
     def test_markseen(self):
         self.page.mark_seen(1004)
         self.page._send.assert_called_once_with('{"message": null, "notification_type": null, '
                                                 '"recipient": {"id": 1004}, '
-                                                '"sender_action": "mark_seen"}')
+                                                '"sender_action": "mark_seen", '
+                                                '"tag": null}')
 
     def test_handle_webhook_errors(self):
         payload = """
@@ -164,7 +167,7 @@ class PageTest(unittest.TestCase):
         def dummy_func():
             pass
 
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(ValueError):
             self.page.set_webhook_handler("shouldfail", dummy_func)
 
         self.page.set_webhook_handler("message", dummy_func)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -115,6 +115,17 @@ class PageTest(unittest.TestCase):
                                                 '"sender_action": "mark_seen", '
                                                 '"tag": null}')
 
+    def test_tag(self):
+        self.page.send(12345, "hello world", quick_replies=[{'title': 'Yes', 'payload': 'YES'}], tag="PAIRING_UPDATE", callback=1)
+        self.page._send.assert_called_once_with('{"message": {"attachment": null, "metadata": null, '
+                                                '"quick_replies": '
+                                                '[{"content_type": "text", "payload": "YES", "title": "Yes"}], '
+                                                '"text": "hello world"},'
+                                                ' "notification_type": null, '
+                                                '"recipient": {"id": 12345}, '
+                                                '"sender_action": null, '
+                                                '"tag": "PAIRING_UPDATE"}', callback=1)
+
     def test_handle_webhook_errors(self):
         payload = """
         {

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -61,6 +61,13 @@ class PayloadTest(unittest.TestCase):
                             sender_action='typing_off',
                             notification_type='NEW_NOTIFICATION_TYPE')
 
+        with self.assertRaises(ValueError):
+            p = Payload.Payload(recipient=recipient,
+                                message=message,
+                                sender_action='typing_off',
+                                notification_type='REGULAR',
+                                tag="BAD_TAG")
+
         p = Payload.Payload(recipient=recipient,
                             message=message,
                             sender_action='typing_off',

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -40,6 +40,11 @@ class PayloadTest(unittest.TestCase):
                           '"quick_replies": [{"content_type": "text", "payload": "PICK_YES", "title": "Yes"}], '
                           '"text": "hello"}', utils.to_json(m))
 
+        m = Payload.Message(text="hello", metadata="METADATA", quick_replies=[{'title': 'Yes', 'payload': 'PICK_YES'}])
+        self.assertEquals('{"attachment": null, "metadata": "METADATA", '
+                          '"quick_replies": [{"content_type": "text", "payload": "PICK_YES", "title": "Yes"}], '
+                          '"text": "hello"}', utils.to_json(m))
+
     def test_payload(self):
         recipient = Payload.Recipient(id=123456, phone_number='+8210')
         message = Payload.Message(text="hello", metadata="METADATA",
@@ -65,8 +70,19 @@ class PayloadTest(unittest.TestCase):
             '{"message": {"attachment": null, "metadata": "METADATA", "quick_replies": '
             '[{"content_type": "text", "payload": "PICK_YES", "title": "Yes"}], "text": "hello"},'
             ' "notification_type": "REGULAR", "recipient": {"id": 123456, "phone_number": "+8210"},'
-            ' "sender_action": "typing_off"}', utils.to_json(p))
+            ' "sender_action": "typing_off", "tag": null}', utils.to_json(p))
+
+        p = Payload.Payload(recipient=recipient,
+                            message=message,
+                            sender_action='typing_off',
+                            notification_type='REGULAR',
+                            tag="PAIRING_UPDATE")
+
+        self.assertEquals(
+            '{"message": {"attachment": null, "metadata": "METADATA", "quick_replies": '
+            '[{"content_type": "text", "payload": "PICK_YES", "title": "Yes"}], "text": "hello"},'
+            ' "notification_type": "REGULAR", "recipient": {"id": 123456, "phone_number": "+8210"},'
+            ' "sender_action": "typing_off", "tag": "PAIRING_UPDATE"}', utils.to_json(p))
 
         self.assertTrue(p.__eq__(p))
         self.assertTrue(p.__eq__(utils.to_json(p)))
-


### PR DESCRIPTION
Requested here: https://github.com/conbus/fbmq/issues/48
Info: https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags

I quickly added the "tag" parameter. If someone can take a look and tell me what I can improve, I will do it.

Thanks