### PR TITLE
Suggestions for maintaining the Event class

### DIFF
--- a/fbmq/events.py
+++ b/fbmq/events.py
@@ -1,0 +1,359 @@
+import json
+
+class Event(object):
+    def __init__(self, sender=None, recipient=None, timestamp=None, **kwargs):
+        if sender is None:
+            sender = dict()
+        if recipient is None:
+            recipient = dict()
+        self.sender = sender
+        self.recipient = recipient
+        self.timestamp = timestamp
+
+    @property
+    def sender_id(self):
+        return self.sender.get('id')
+
+    @property
+    def recipient_id(self):
+        return self.recipient.get('id')
+
+    @classmethod
+    def new_from_json_dict(cls, data):
+        return cls(**data)
+
+    def __str__(self):
+        return json.dumps(self.__name__)
+
+
+class MessageEvent(Event):
+    def __init__(self, message, **kwargs):
+        super(MessageEvent, self).__init__(**kwargs)
+
+        self.name = 'message'
+        self.message = message
+
+    @property
+    def mid(self):
+        return self.message.get('mid')
+
+    @property
+    def text(self):
+        return self.message.get('text')
+
+    @property
+    def attachments(self):
+        return self.message.get('attachments', [])
+
+    @property
+    def quick_reply(self):
+        return self.message.get('quick_reply', {})
+
+    @property
+    def quick_reply_payload(self):
+        return self.quick_reply.get('payload')
+
+    @property
+    def is_quick_reply(self):
+        return self.message.get('quick_reply') is not None
+
+
+class DeliveriesEvent(Event):
+    def __init__(self, delivery, **kwargs):
+        super(DeliveriesEvent, self).__init__(**kwargs)
+
+        self.name = 'delivery'
+        self.delivery = delivery
+
+    @property
+    def mids(self):
+        return self.delivery.get('mids')
+
+    @property
+    def watermark(self):
+        return self.delivery.get('watermark')
+
+    @property
+    def seq(self):
+        return self.delivery.get('seq')
+
+
+class EchoEvent(Event):
+    def __init__(self, message, **kwargs):
+        super(EchoEvent, self).__init__(**kwargs)
+
+        self.name = 'echo'
+        self.message = message
+
+    @property
+    def mid(self):
+        return self.message.get('mid')
+
+    @property
+    def app_id(self):
+        return self.message.get('app_id')
+
+    @property
+    def metadata(self):
+        return self.message.get('metadata')
+
+    @property
+    def text(self):
+        return self.message.get('text')
+
+    @property
+    def attachments(self):
+        return self.message.get('attachments')
+
+
+class ReadEvent(Event):
+    def __init__(self, read, **kwargs):
+        super(ReadEvent, self).__init__(**kwargs)
+
+        self.name = 'read'
+        self.read = read
+
+    @property
+    def seq(self):
+        return self.read.get('seq')
+
+    @property
+    def watermark(self):
+        return self.read.get('watermark')
+
+
+class AccountLinkingEvent(Event):
+    def __init__(self, account_linking, **kwargs):
+        super(AccountLinkingEvent, self).__init__(**kwargs)
+
+        self.name = 'account_linking'
+        self.account_linking = account_linking
+
+    @property
+    def status(self):
+        return self.account_linking.get('status')
+
+    @property
+    def is_linked(self):
+        return self.status == 'linked'
+
+    @property
+    def authorization_code(self):
+        return self.account_linking.get('authorization_code')
+
+
+class GamePlayEvent(Event):
+    def __init__(self, game_play, **kwargs):
+        super(GamePlayEvent, self).__init__(**kwargs)
+
+        self.name = 'game_play'
+        self.game_play = game_play
+
+    @property
+    def game_id(self):
+        return self.game_play.get('game_id')
+
+    @property
+    def player_id(self):
+        return self.game_play.get('player_id')
+
+    @property
+    def context_type(self):
+        return self.game_play.get('context_type')
+
+    @property
+    def context_id(self):
+        return self.game_play.get('context_id')
+
+    @property
+    def score(self):
+        return self.game_play.get('score')
+
+    @property
+    def payload(self):
+        return self.game_play.get('score')
+
+
+class PassThreadEvent(Event):
+    def __init__(self, pass_thread_control, **kwargs):
+        super(PassThreadEvent, self).__init__(**kwargs)
+
+        self.name = 'pass_thread_control'
+        self.pass_thread_control = pass_thread_control
+
+    @property
+    def previous_owner_app_id(self):
+        return self.pass_thread_control.get('previous_owner_app_id')
+
+    @property
+    def metadata(self):
+        return self.pass_thread_control.get('metadata')
+
+
+class TakeThreadEvent(Event):
+    def __init__(self, take_thread_control, **kwargs):
+        super(TakeThreadEvent, self).__init__(**kwargs)
+
+        self.name = 'take_thread_control'
+        self.take_thread_control = take_thread_control
+
+    @property
+    def previous_owner_app_id(self):
+        return self.take_thread_control.get('previous_owner_app_id')
+
+    @property
+    def metadata(self):
+        return self.take_thread_control.get('metadata')
+
+
+class RequestThreadEvent(Event):
+    def __init__(self, request_thread_control, **kwargs):
+        super(RequestThreadEvent, self).__init__(**kwargs)
+
+        self.name = 'request_thread_control'
+        self.request_thread_control = request_thread_control
+
+    @property
+    def previous_owner_app_id(self):
+        return self.request_thread_control.get('previous_owner_app_id')
+
+    @property
+    def metadata(self):
+        return self.request_thread_control.get('metadata')
+
+
+class AppRoleEvent(Event):
+    def __init__(self, app_roles, **kwargs):
+        super(AppRoleEvent, self).__init__(**kwargs)
+
+        self.name = 'app_roles'
+        self.app_roles = app_roles
+
+
+class OptinEvent(Event):
+    def __init__(self, optin, **kwargs):
+        super(OptinEvent, self).__init__(**kwargs)
+
+        self.name = 'optin'
+        self.optin = optin
+
+    @property
+    def ref(self):
+        return self.optin.get('ref')
+
+    @property
+    def user_ref(self):
+        return self.optin.get('user_ref')
+
+
+class PolicyEnforcementEvent(Event):
+    def __init__(self, policy_enforcement, **kwargs):
+        super(PolicyEnforcementEvent, self).__init__(**kwargs)
+
+        self.name = 'policy_enforcement'
+        self.policy_enforcement = policy_enforcement
+
+    @property
+    def action(self):
+        return self.policy_enforcement.get('action')
+
+    @property
+    def reason(self):
+        return self.policy_enforcement.get('reason')
+
+
+class PostBackEvent(Event):
+    def __init__(self, postback, **kwargs):
+        super(PostBackEvent, self).__init__(**kwargs)
+
+        self.name = 'postback'
+        self.postback = postback
+
+    @property
+    def title(self):
+        return self.postback.get('title')
+
+    @property
+    def payload(self):
+        return self.postback.get('payload')
+
+    @property
+    def referral(self):
+        return self.postback.get('referral')
+
+
+class ReferralEvent(Event):
+    def __init__(self, referral, **kwargs):
+        super(ReferralEvent, self).__init__(**kwargs)
+
+        self.name = 'referral'
+        self.referral = referral
+
+    @property
+    def source(self):
+        return self.referral.get('source')
+
+    @property
+    def type(self):
+        return self.referral.get('type')
+
+    @property
+    def ref(self):
+        return self.referral.get('ref')
+
+    @property
+    def referer_uri(self):
+        return self.referral.get('referer_uri')
+
+
+class CheckOutUpdateEvent(Event): #beta
+    def __init__(self, checkout_update, **kwargs):
+        super(CheckOutUpdateEvent, self).__init__(**kwargs)
+
+        self.name = 'checkout_update'
+        self.checkout_update = checkout_update
+
+    @property
+    def payload(self):
+        return self.checkout_update.get('payload')
+
+    @property
+    def shipping_address(self):
+        return self.checkout_update.get('shipping_address')
+
+
+class PaymentEvent(Event): #beta
+    def __init__(self, payment, **kwargs):
+        super(PaymentEvent, self).__init__(**kwargs)
+
+        self.name = 'payment'
+        self.payment = payment
+
+    @property
+    def payload(self):
+        return self.payment.get('payload')
+
+    @property
+    def requested_user_info(self):
+        return self.payment.get('requested_user_info')
+
+    @property
+    def payment_credential(self):
+        return self.payment.get('payment_credential')
+
+    @property
+    def amount(self):
+        return self.payment.get('amount')
+
+    @property
+    def shipping_option_id(self):
+        return self.payment.get('shipping_option_id')
+
+
+class StandByEvent(Event):
+    # sugget me to handle it.
+    pass
+
+
+class PrecheckoutEvent(Event): # beta
+    pass

--- a/fbmq/events.py
+++ b/fbmq/events.py
@@ -351,7 +351,7 @@ class PaymentEvent(Event): #beta
 
 
 class StandByEvent(Event):
-    # sugget me to handle it.
+    # suggest me to handle it.
     pass
 
 

--- a/fbmq/events.py
+++ b/fbmq/events.py
@@ -23,7 +23,7 @@ class Event(object):
         return cls(**data)
 
     def __str__(self):
-        return json.dumps(self.__name__)
+        return json.dumps(self.__class__.__name__)
 
 
 class MessageEvent(Event):
@@ -171,7 +171,7 @@ class GamePlayEvent(Event):
 
     @property
     def payload(self):
-        return self.game_play.get('score')
+        return self.game_play.get('payload')
 
 
 class PassThreadEvent(Event):
@@ -182,8 +182,8 @@ class PassThreadEvent(Event):
         self.pass_thread_control = pass_thread_control
 
     @property
-    def previous_owner_app_id(self):
-        return self.pass_thread_control.get('previous_owner_app_id')
+    def new_owner_app_id(self):
+        return self.pass_thread_control.get('new_owner_app_id')
 
     @property
     def metadata(self):
@@ -214,8 +214,8 @@ class RequestThreadEvent(Event):
         self.request_thread_control = request_thread_control
 
     @property
-    def previous_owner_app_id(self):
-        return self.request_thread_control.get('previous_owner_app_id')
+    def requested_owner_app_id(self):
+        return self.request_thread_control.get('requested_owner_app_id')
 
     @property
     def metadata(self):

--- a/fbmq/fbmq.py
+++ b/fbmq/fbmq.py
@@ -288,7 +288,7 @@ class Page(object):
                 self._call_handler('pass_thread_control', pass_thread_control, event)
             elif isinstance(event, TakeThreadEvent):
                 self._call_handler('take_thread_control', take_thread_control, event)
-            elif isinstance(event, ReferralEvent):
+            elif isinstance(event, RequestThreadEvent):
                 self._call_handler('request_thread_control', request_thread_control, event)
             elif isinstance(event, AppRoleEvent):
                 self._call_handler('app_roles', app_roles, event)
@@ -569,7 +569,7 @@ class Page(object):
         self._webhook_handlers['take_thread_control'] = func
 
     def handle_request_thread_control(self, func):
-        self._webhook_handlers['reqeust_thread_control'] = func
+        self._webhook_handlers['request_thread_control'] = func
 
     def handle_app_roles(self, func):
         self._webhook_handlers['app_roles'] = func

--- a/fbmq/fbmq.py
+++ b/fbmq/fbmq.py
@@ -182,7 +182,9 @@ def event_parser(messaging=None):
     elif 'payment' in messaging:
         event_type = PaymentEvent
     elif 'policy-enforcement' in messaging:
-        # must be modified later!!!!!!!!!!
+        # key name must be changed for properly use to class instance.
+        messaging['policy_enforcement'] = messaging['policy-enforcement']
+        del messaging['policy-enforcement']
         event_type = PolicyEnforcementEvent
     elif 'postback' in messaging:
         event_type = PostBackEvent

--- a/fbmq/fbmq.py
+++ b/fbmq/fbmq.py
@@ -232,7 +232,10 @@ class Page(object):
             print("there's no %s handler" % name)
 
     def handle_webhook(self, payload, optin=None, message=None, echo=None, delivery=None,
-                       postback=None, read=None, account_linking=None, referral=None):
+                       postback=None, read=None, account_linking=None, referral=None,
+                       game_play=None, pass_thread_control=None, take_thread_control=None,
+                       request_thread_control=None, app_roles=None, policy_enforcement=None,
+                       checkout_update=None, payment=None):
         data = json.loads(payload)
 
         # Make sure this is a page subscription
@@ -276,6 +279,23 @@ class Page(object):
                 self._call_handler('account_linking', account_linking, event)
             elif isinstance(event, ReferralEvent):
                 self._call_handler('referral', referral, event)
+
+            elif isinstance(event, GamePlayEvent):
+                self._call_handler('game_play', game_play, event)
+            elif isinstance(event, PassThreadEvent):
+                self._call_handler('pass_thread_control', pass_thread_control, event)
+            elif isinstance(event, TakeThreadEvent):
+                self._call_handler('take_thread_control', take_thread_control, event)
+            elif isinstance(event, ReferralEvent):
+                self._call_handler('request_thread_control', request_thread_control, event)
+            elif isinstance(event, AppRoleEvent):
+                self._call_handler('app_roles', app_roles, event)
+            elif isinstance(event, PolicyEnforcementEvent):
+                self._call_handler('policy_enforcement', policy_enforcement, event)
+            elif isinstance(event ,CheckOutUpdateEvent):
+                self._call_handler('checkout_update', checkout_update, event)
+            elif isinstance(event, PaymentEvent):
+                self._call_handler('payment', payment, event)
             else:
                 print("Webhook received unknown messaging Event:", event)
 
@@ -536,6 +556,30 @@ class Page(object):
 
     def handle_referral(self, func):
         self._webhook_handlers['referral'] = func
+
+    def handle_game_play(self, func):
+        self._webhook_handlers['game_play'] = func
+
+    def handle_pass_thread_control(self, func):
+        self._webhook_handlers['pass_thread_control'] = func
+
+    def handle_take_thread_control(self, func):
+        self._webhook_handlers['take_thread_control'] = func
+
+    def handle_request_thread_control(self, func):
+        self._webhook_handlers['reqeust_thread_control'] = func
+
+    def handle_app_roles(self, func):
+        self._webhook_handlers['app_roles'] = func
+
+    def handle_policy_enforcement(self, func):
+        self._webhook_handlers['policy_enforcement'] = func
+
+    def handle_checkout_update(self, func):
+        self._webhook_handlers['checkout_update'] = func
+
+    def handle_payment(self, func):
+        self._webhook_handlers['payment'] = func
 
     def after_send(self, func):
         self._after_send = func

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,212 @@
+import unittest
+from fbmq.events import *
+
+class TestEvents(unittest.TestCase):
+    def test_message_event(self):
+        quick_reply_payload = {
+              "sender":{
+                "id":"PSID"
+              },
+              "recipient":{
+                "id":"PAGE_ID"
+              },
+              "timestamp":1458692752478,
+              "message":{
+                "mid":"mid.1457764197618:41d102a3e1ae206a38",
+                "text":"hello, world!",
+                "quick_reply": {
+                  "payload": "<DEVELOPER_DEFINED_PAYLOAD>"
+                }
+              }
+            }
+        event = MessageEvent.new_from_json_dict(quick_reply_payload)
+
+        self.assertEqual(event.sender_id, 'PSID')
+        self.assertEqual(event.recipient_id, 'PAGE_ID')
+        self.assertEqual(event.text, 'hello, world!')
+        self.assertEqual(event.quick_reply_payload, '<DEVELOPER_DEFINED_PAYLOAD>')
+        self.assertTrue(event.is_quick_reply)
+        self.assertFalse(event.attachments)
+
+        attachments_payload = {
+              "sender":{
+                "id":"PSID"
+              },
+              "recipient":{
+                "id":"PAGE_ID"
+              },
+              "timestamp":1458692752478,
+              "message":{
+                "mid":"mid.1458696618141:b4ef9d19ec21086067",
+                "attachments":[
+                  {
+                    "type":"image",
+                    "payload":{
+                      "url":"IMAGE_URL"
+                    }
+                  }
+                ]
+              }
+            }
+        event2 = MessageEvent.new_from_json_dict(attachments_payload)
+
+        self.assertEqual(event2.sender_id, 'PSID')
+        self.assertEqual(event2.recipient_id, 'PAGE_ID')
+        self.assertEqual(event2.text, None)
+        self.assertEqual(event2.quick_reply_payload, None)
+        self.assertFalse(event2.is_quick_reply)
+        self.assertEqual(
+            event2.attachments,
+            [
+                {
+                    "type": "image",
+                    "payload": {
+                        "url": "IMAGE_URL"
+                    }
+                }
+            ]
+        )
+
+    def test_account_linking_event(self):
+        linked_payload = {
+              "sender":{
+                "id":"USER_ID"
+              },
+              "recipient":{
+                "id":"PAGE_ID"
+              },
+              "timestamp":1234567890,
+              "account_linking":{
+                "status":"linked",
+                "authorization_code":"PASS_THROUGH_AUTHORIZATION_CODE"
+              }
+            }
+
+        event = AccountLinkingEvent.new_from_json_dict(linked_payload)
+        self.assertEqual(event.sender_id, 'USER_ID')
+        self.assertEqual(event.recipient_id, 'PAGE_ID')
+        self.assertEqual(event.status, 'linked')
+        self.assertTrue(event.is_linked)
+        self.assertEqual(event.authorization_code, "PASS_THROUGH_AUTHORIZATION_CODE")
+
+        unlinked_payload = {
+              "sender":{
+                "id":"USER_ID"
+              },
+              "recipient":{
+                "id":"PAGE_ID"
+              },
+              "timestamp":1234567890,
+              "account_linking":{
+                "status":"unlinked"
+              }
+            }
+        event = AccountLinkingEvent.new_from_json_dict(unlinked_payload)
+        self.assertEqual(event.sender_id, 'USER_ID')
+        self.assertEqual(event.recipient_id, 'PAGE_ID')
+        self.assertEqual(event.status, 'unlinked')
+        self.assertFalse(event.is_linked)
+        self.assertEqual(event.authorization_code, None)
+
+    def test_deliveries_event(self):
+        payload = {
+              "sender":{
+                "id":"<PSID>"
+              },
+              "recipient":{
+                "id":"<PAGE_ID>"
+              },
+               "delivery":{
+                  "mids":[
+                     "mid.1458668856218:ed81099e15d3f4f233"
+                  ],
+                  "watermark":1458668856253,
+                  "seq":37
+               }
+            }
+        event = DeliveriesEvent.new_from_json_dict(payload)
+        self.assertEqual(event.watermark, 1458668856253)
+        self.assertEqual(event.seq, 37)
+        self.assertEqual(event.mids, ["mid.1458668856218:ed81099e15d3f4f233"])
+
+    def test_echo_event(self):
+        payload = {
+            "sender": {
+                "id": "USER_ID"
+            },
+            "recipient": {
+                "id": "PAGE_ID"
+            },
+            "timestamp": 1457764197627,
+            "message": {
+                "is_echo": True,
+                "app_id": 1517776481860111,
+                "metadata": "<DEVELOPER_DEFINED_METADATA_STRING>",
+                "mid": "mid.1457764197618:41d102a3e1ae206a38",
+                "text": "hello, world!"
+            }
+        }
+
+        event = EchoEvent.new_from_json_dict(payload)
+        self.assertEqual(event.sender_id, 'USER_ID')
+        self.assertEqual(event.recipient_id, 'PAGE_ID')
+        self.assertEqual(event.app_id, 1517776481860111)
+        self.assertEqual(event.metadata, "<DEVELOPER_DEFINED_METADATA_STRING>")
+        self.assertEqual(event.text, "hello, world!")
+        self.assertEqual(event.attachments, None)
+
+    def test_optin_event(self):
+        """
+        Need Payload Information...
+        """
+        pass
+
+    def test_postback_event(self):
+        payload = {
+            "sender": {
+                "id": "<PSID>"
+            },
+            "recipient": {
+                "id": "<PAGE_ID>"
+            },
+            "timestamp": 1458692752478,
+            "postback": {
+                "title": "<TITLE_FOR_THE_CTA>",
+                "payload": "<USER_DEFINED_PAYLOAD>",
+                "referral": {
+                    "ref": "<USER_DEFINED_REFERRAL_PARAM>",
+                    "source": "<SHORTLINK>",
+                    "type": "OPEN_THREAD",
+                }
+            }
+        }
+
+        event = PostBackEvent.new_from_json_dict(payload)
+        self.assertEqual(event.sender_id, "<PSID>")
+        self.assertEqual(event.recipient_id, "<PAGE_ID>")
+        self.assertEqual(event.timestamp, 1458692752478)
+        self.assertEqual(event.title, '<TITLE_FOR_THE_CTA>')
+        self.assertEqual(event.payload, '<USER_DEFINED_PAYLOAD>')
+
+    def test_read_event(self):
+        payload = {
+            "sender": {
+                "id": "<PSID>"
+            },
+            "recipient": {
+                "id": "<PAGE_ID>"
+            },
+            "timestamp": 1458668856463,
+            "read": {
+                "watermark": 1458668856253,
+                "seq": 38
+            }
+        }
+
+        event = ReadEvent.new_from_json_dict(payload)
+        self.assertTrue(isinstance(event, ReadEvent))
+        self.assertEqual(event.sender_id, '<PSID>')
+        self.assertEqual(event.recipient_id, '<PAGE_ID>')
+        self.assertEqual(event.timestamp, 1458668856463)
+        self.assertEqual(event.seq, 38)
+        self.assertEqual(event.watermark, 1458668856253)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -4,6 +4,7 @@ import mock
 import responses
 from fbmq.fbmq import Page, LocalizedObj, SUPPORTED_API_VERS
 from fbmq import template as Template
+from fbmq import events as Event
 
 
 class MessengerAPIMock():
@@ -205,22 +206,14 @@ class PageTest(unittest.TestCase):
 
         @self.page.handle_message
         def handler1(event):
-            self.assertTrue(event.is_message)
-            self.assertTrue(event.is_text_message)
-            self.assertFalse(event.is_attachment_message)
+            self.assertTrue(event, Event.MessageEvent)
+            self.assertEqual(event.name, 'message')
+            self.assertEqual(event.attachments, [])
             self.assertFalse(event.is_quick_reply)
-            self.assertFalse(event.is_echo)
-            self.assertFalse(event.is_read)
-            self.assertFalse(event.is_postback)
-            self.assertFalse(event.is_postback_referral)
-            self.assertFalse(event.is_optin)
-            self.assertFalse(event.is_delivery)
-            self.assertFalse(event.is_account_linking)
-            self.assertFalse(event.is_referral)
             self.assertEquals(event.timestamp, 1472026867080)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
-            self.assertEquals(event.message_text, 'hello world')
+            self.assertEquals(event.text, 'hello world')
             counter()
 
         self.page.handle_webhook(payload)
@@ -246,22 +239,13 @@ class PageTest(unittest.TestCase):
 
         @self.page.handle_read
         def handler1(event):
-            self.assertFalse(event.is_message)
-            self.assertFalse(event.is_text_message)
-            self.assertFalse(event.is_attachment_message)
-            self.assertFalse(event.is_quick_reply)
-            self.assertFalse(event.is_echo)
-            self.assertTrue(event.is_read)
-            self.assertFalse(event.is_postback)
-            self.assertFalse(event.is_postback_referral)
-            self.assertFalse(event.is_optin)
-            self.assertFalse(event.is_delivery)
-            self.assertFalse(event.is_account_linking)
-            self.assertFalse(event.is_referral)
+            self.assertTrue(isinstance(event, Event.ReadEvent))
+            self.assertEqual(event.name, 'read')
+            self.assertEqual(event.seq, 814)
+            self.assertEqual(event.watermark, 1472026868763)
             self.assertEquals(event.timestamp, 1472026869186)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
-            self.assertEquals(event.message_text, None)
             counter()
 
         self.page.handle_webhook(payload)
@@ -288,22 +272,14 @@ class PageTest(unittest.TestCase):
 
         @self.page.handle_echo
         def handler1(event):
-            self.assertTrue(event.is_message)
-            self.assertTrue(event.is_text_message)
-            self.assertFalse(event.is_attachment_message)
-            self.assertFalse(event.is_quick_reply)
-            self.assertTrue(event.is_echo)
-            self.assertFalse(event.is_read)
-            self.assertFalse(event.is_postback)
-            self.assertFalse(event.is_postback_referral)
-            self.assertFalse(event.is_optin)
-            self.assertFalse(event.is_delivery)
-            self.assertFalse(event.is_account_linking)
-            self.assertFalse(event.is_referral)
+            self.assertTrue(isinstance(event, Event.EchoEvent))
+            self.assertEqual(event.name, 'echo')
+            self.assertEqual(event.mid, "mid.1472026868734:832ecbdfc1ffc30139")
+            self.assertEqual(event.app_id, 950864918368986)
+            self.assertEqual(event.text, 'hello')
             self.assertEquals(event.timestamp, 1472026868763)
             self.assertEquals(event.sender_id, '1691462197845448')
             self.assertEquals(event.recipient_id, '1134343043305865')
-            self.assertEquals(event.message_text, 'hello')
             counter()
 
         self.page.handle_webhook(payload)
@@ -328,22 +304,14 @@ class PageTest(unittest.TestCase):
 
         @self.page.handle_delivery
         def handler1(event):
-            self.assertFalse(event.is_message)
-            self.assertFalse(event.is_text_message)
-            self.assertFalse(event.is_attachment_message)
-            self.assertFalse(event.is_quick_reply)
-            self.assertFalse(event.is_echo)
-            self.assertFalse(event.is_read)
-            self.assertFalse(event.is_postback)
-            self.assertFalse(event.is_postback_referral)
-            self.assertFalse(event.is_optin)
-            self.assertTrue(event.is_delivery)
-            self.assertFalse(event.is_account_linking)
-            self.assertFalse(event.is_referral)
+            self.assertTrue(isinstance(event, Event.DeliveriesEvent))
+            self.assertEqual(event.name, 'delivery')
+            self.assertEqual(event.mids, ["mid.1472028395154:917e24ea99bc7d8f11"])
+            self.assertEqual(event.watermark, 1472028395190)
+            self.assertEqual(event.seq, 821)
             self.assertEquals(event.timestamp, 0)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
-            self.assertEquals(event.message_text, None)
             counter()
 
         self.page.handle_webhook(payload)
@@ -368,22 +336,14 @@ class PageTest(unittest.TestCase):
 
         @self.page.handle_account_linking
         def handler1(event):
-            self.assertFalse(event.is_message)
-            self.assertFalse(event.is_text_message)
-            self.assertFalse(event.is_attachment_message)
-            self.assertFalse(event.is_quick_reply)
-            self.assertFalse(event.is_echo)
-            self.assertFalse(event.is_read)
-            self.assertFalse(event.is_postback)
-            self.assertFalse(event.is_postback_referral)
-            self.assertFalse(event.is_optin)
-            self.assertFalse(event.is_delivery)
-            self.assertTrue(event.is_account_linking)
-            self.assertFalse(event.is_referral)
+            self.assertTrue(isinstance(event, Event.AccountLinkingEvent))
+            self.assertEqual(event.name, 'account_linking')
+            self.assertEqual(event.status, 'linked')
+            self.assertTrue(event.is_linked)
+            self.assertEqual(event.authorization_code, "1234567890")
             self.assertEquals(event.timestamp, 1472028542079)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
-            self.assertEquals(event.message_text, None)
             counter()
 
         self.page.handle_webhook(payload)
@@ -408,23 +368,15 @@ class PageTest(unittest.TestCase):
 
         @self.page.handle_referral
         def handler1(event):
-            self.assertFalse(event.is_message)
-            self.assertFalse(event.is_text_message)
-            self.assertFalse(event.is_attachment_message)
-            self.assertFalse(event.is_quick_reply)
-            self.assertFalse(event.is_echo)
-            self.assertFalse(event.is_read)
-            self.assertFalse(event.is_postback)
-            self.assertFalse(event.is_postback_referral)
-            self.assertFalse(event.is_optin)
-            self.assertFalse(event.is_delivery)
-            self.assertFalse(event.is_account_linking)
-            self.assertTrue(event.is_referral)
+            self.assertTrue(isinstance(event, Event.ReferralEvent))
+            self.assertEqual(event.name, 'referral')
+            self.assertEqual(event.source, 'SHORTLINK')
+            self.assertEqual(event.type, 'OPEN_THREAD')
+            self.assertEqual(event.ref, 'REFTEST')
+            self.assertEqual(event.referer_uri, None)
             self.assertEquals(event.timestamp, 1472028542079)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
-            self.assertEquals(event.message_text, None)
-            self.assertEqual(event.referral_ref, 'REFTEST')
             counter()
 
         self.page.handle_webhook(payload)
@@ -450,24 +402,13 @@ class PageTest(unittest.TestCase):
 
         @self.page.handle_postback
         def handler1(event):
-            self.assertFalse(event.is_message)
-            self.assertFalse(event.is_text_message)
-            self.assertFalse(event.is_attachment_message)
-            self.assertFalse(event.is_quick_reply)
-            self.assertFalse(event.is_echo)
-            self.assertFalse(event.is_read)
-            self.assertTrue(event.is_postback)
-            self.assertFalse(event.is_postback_referral)
-            self.assertFalse(event.is_optin)
-            self.assertFalse(event.is_delivery)
-            self.assertFalse(event.is_account_linking)
-            self.assertFalse(event.is_referral)
+            self.assertTrue(isinstance(event, Event.PostBackEvent))
+            self.assertEqual(event.name, 'postback')
+            self.assertEqual(event.title, None)
+            self.assertEqual(event.payload, 'DEVELOPED_DEFINED_PAYLOAD')
             self.assertEquals(event.timestamp, 1472028006107)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
-            self.assertEquals(event.message_text, None)
-            self.assertEquals(event.postback_payload, 'DEVELOPED_DEFINED_PAYLOAD')
-            self.assertEquals(event.postback_payload, event.postback.get('payload'))
             counter1()
 
         self.page.handle_webhook(payload)
@@ -494,26 +435,13 @@ class PageTest(unittest.TestCase):
 
         @self.page.handle_postback
         def handler1(event):
-            self.assertFalse(event.is_message)
-            self.assertFalse(event.is_text_message)
-            self.assertFalse(event.is_attachment_message)
-            self.assertFalse(event.is_quick_reply)
-            self.assertFalse(event.is_echo)
-            self.assertFalse(event.is_read)
-            self.assertTrue(event.is_postback)
-            self.assertTrue(event.is_postback_referral)
-            self.assertFalse(event.is_optin)
-            self.assertFalse(event.is_delivery)
-            self.assertFalse(event.is_account_linking)
-            self.assertFalse(event.is_referral)
+            self.assertTrue(isinstance(event, Event.PostBackEvent))
+            self.assertEqual(event.name, 'postback')
+            self.assertEquals(event.payload, 'DEVELOPED_DEFINED_PAYLOAD')
+            self.assertEquals(event.referral, {"ref":"REFTEST","source":"SHORTLINK","type": "OPEN_THREAD"})
             self.assertEquals(event.timestamp, 1472028006107)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
-            self.assertEquals(event.message_text, None)
-            self.assertEquals(event.postback_payload, 'DEVELOPED_DEFINED_PAYLOAD')
-            self.assertEquals(event.postback_payload, event.postback.get('payload'))
-            self.assertEquals(event.postback_referral, event.postback.get('referral'))
-            self.assertEquals(event.postback_referral_ref, 'REFTEST')
             counter1()
 
         self.page.handle_webhook(payload)
@@ -539,23 +467,10 @@ class PageTest(unittest.TestCase):
         counter2 = mock.MagicMock()
 
         def handler1(event):
-            self.assertFalse(event.is_message)
-            self.assertFalse(event.is_text_message)
-            self.assertFalse(event.is_attachment_message)
-            self.assertFalse(event.is_quick_reply)
-            self.assertFalse(event.is_echo)
-            self.assertFalse(event.is_read)
-            self.assertTrue(event.is_postback)
-            self.assertFalse(event.is_postback_referral)
-            self.assertFalse(event.is_optin)
-            self.assertFalse(event.is_delivery)
-            self.assertFalse(event.is_account_linking)
-            self.assertFalse(event.is_referral)
+            self.assertTrue(isinstance(event, Event.PostBackEvent))
             self.assertEquals(event.timestamp, 1472028006107)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
-            self.assertEquals(event.message_text, None)
-            self.assertEquals(event.postback_payload, event.postback.get('payload'))
             counter1()
 
         @self.page.callback(['DEVELOPED_DEFINED_PAYLOAD'], types=['POSTBACK'])
@@ -590,23 +505,13 @@ class PageTest(unittest.TestCase):
 
         @self.page.handle_message
         def handler1(event):
-            self.assertTrue(event.is_message)
-            self.assertTrue(event.is_text_message)
-            self.assertFalse(event.is_attachment_message)
+            self.assertTrue(isinstance(event, Event.MessageEvent))
+            self.assertEqual(event.name, 'message')
             self.assertTrue(event.is_quick_reply)
-            self.assertFalse(event.is_echo)
-            self.assertFalse(event.is_read)
-            self.assertFalse(event.is_postback)
-            self.assertFalse(event.is_postback_referral)
-            self.assertFalse(event.is_optin)
-            self.assertFalse(event.is_delivery)
-            self.assertFalse(event.is_account_linking)
-            self.assertFalse(event.is_referral)
+            self.assertEquals(event.text, 'Action')
             self.assertEquals(event.timestamp, 1472028637825)
             self.assertEquals(event.sender_id, '1134343043305865')
             self.assertEquals(event.recipient_id, '1691462197845448')
-            self.assertEquals(event.message_text, 'Action')
-            self.assertEquals(event.quick_reply_payload, event.quick_reply.get('payload'))
             counter1()
 
         @self.page.callback(['PICK_ACTION'], types=['QUICK_REPLY'])

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -455,6 +455,408 @@ class PageTest(unittest.TestCase):
         self.page.handle_webhook(payload, postback=handler2)
         self.assertEquals(1, counter2.call_count)
 
+    def test_handle_game_play(self):
+        payload = """{"object":"page","entry":[{"id":"1691462197845448","time":1472028006107,
+        "messaging":[{
+          "sender": {
+            "id": "<PSID>"
+          },
+          "recipient": {
+            "id": "<PAGE_ID>"
+          },
+          "timestamp": 1469111400000,
+          "game_play": {
+            "game_id": "<GAME-APP-ID>",
+            "player_id": "<PLAYER-ID>",
+            "context_type": "<CONTEXT-TYPE:SOLO|THREAD>",
+            "context_id": "<CONTEXT-ID>",
+            "score": "<SCORE-NUM>", 
+            "payload": "<PAYLOAD>"
+          }}]
+        }]}"""
+
+        counter1 = mock.MagicMock()
+
+        @self.page.handle_game_play
+        def handler1(event):
+            self.assertTrue(isinstance(event, Event.GamePlayEvent))
+            self.assertEqual(event.name, 'game_play')
+            self.assertEqual(event.sender_id, "<PSID>")
+            self.assertEqual(event.recipient_id, "<PAGE_ID>")
+            self.assertEqual(event.game_id, "<GAME-APP-ID>")
+            self.assertEqual(event.player_id, "<PLAYER-ID>")
+            self.assertEqual(event.context_type, "<CONTEXT-TYPE:SOLO|THREAD>")
+            self.assertEqual(event.context_id, "<CONTEXT-ID>")
+            self.assertEqual(event.score, "<SCORE-NUM>")
+            self.assertEqual(event.payload, "<PAYLOAD>")
+            self.assertEqual(event.timestamp, 1469111400000)
+            counter1()
+
+        self.page.handle_webhook(payload)
+        self.assertEquals(1, counter1.call_count)
+
+        counter2 = mock.MagicMock()
+
+        def handler2(event):
+            counter2()
+
+        self.page.handle_webhook(payload, game_play=handler2)
+        self.assertEquals(1, counter2.call_count)
+
+    def test_handle_pass_thread_control(self):
+        payload = """
+                {"object":"page","entry":[{"id":"1691462197845448","time":1472028006107,
+                "messaging":[{
+                      "sender":{
+                        "id":"<PSID>"
+                      },
+                      "recipient":{
+                        "id":"<PAGE_ID>"
+                      },
+                      "timestamp":1458692752478,
+                      "pass_thread_control":{
+                        "new_owner_app_id":"123456789",
+                        "metadata":"Additional content that the caller wants to set"
+                      }
+                    }]
+                }]}
+                """
+        counter1 = mock.MagicMock()
+
+        @self.page.handle_pass_thread_control
+        def handler1(event):
+            self.assertTrue(isinstance(event, Event.PassThreadEvent))
+            self.assertEqual(event.name, 'pass_thread_control')
+            self.assertEqual(event.new_owner_app_id, "123456789")
+            self.assertEqual(event.metadata, "Additional content that the caller wants to set")
+            self.assertEquals(event.timestamp, 1458692752478)
+            self.assertEquals(event.sender_id, '<PSID>')
+            self.assertEquals(event.recipient_id, '<PAGE_ID>')
+            counter1()
+
+        self.page.handle_webhook(payload)
+        self.assertEquals(1, counter1.call_count)
+
+        counter2 = mock.MagicMock()
+
+        def handler2(event):
+            counter2()
+
+        self.page.handle_webhook(payload, pass_thread_control=handler2)
+        self.assertEquals(1, counter2.call_count)
+
+    def test_handle_take_thread_control(self):
+        payload = """
+                {"object":"page","entry":[{"id":"1691462197845448","time":1472028006107,
+                    "messaging":[{
+                      "sender":{
+                        "id":"<USER_ID>"
+                      },
+                      "recipient":{
+                        "id":"<PSID>"
+                      },
+                      "timestamp":1458692752478,
+                      "take_thread_control":{
+                        "previous_owner_app_id":"123456789",
+                        "metadata":"additional content that the caller wants to set"
+                      }
+                    }]
+                }]}
+                """
+        counter1 = mock.MagicMock()
+
+        @self.page.handle_take_thread_control
+        def handler1(event):
+            self.assertTrue(isinstance(event, Event.TakeThreadEvent))
+            self.assertEqual(event.name, 'take_thread_control')
+            self.assertEqual(event.previous_owner_app_id, "123456789")
+            self.assertEqual(event.metadata, "additional content that the caller wants to set")
+            self.assertEquals(event.timestamp, 1458692752478)
+            self.assertEquals(event.sender_id, '<USER_ID>')
+            self.assertEquals(event.recipient_id, '<PSID>')
+            counter1()
+
+        self.page.handle_webhook(payload)
+        self.assertEquals(1, counter1.call_count)
+
+        counter2 = mock.MagicMock()
+
+        def handler2(event):
+            counter2()
+
+        self.page.handle_webhook(payload, take_thread_control=handler2)
+        self.assertEquals(1, counter2.call_count)
+
+    def test_handle_reqeust_thread_control(self):
+        payload = """
+                {"object":"page","entry":[{"id":"1691462197845448","time":1472028006107,
+                    "messaging":[{
+                      "sender":{
+                        "id":"<USER_ID>"
+                      },
+                      "recipient":{
+                        "id":"<PSID>"
+                      },
+                      "timestamp":1458692752478,
+                      "request_thread_control":{
+                        "requested_owner_app_id":123456789,
+                        "metadata":"additional content that the caller wants to set"
+                      }
+                    }]
+                }]}
+                """
+        counter1 = mock.MagicMock()
+
+        @self.page.handle_request_thread_control
+        def handler1(event):
+            self.assertTrue(isinstance(event, Event.RequestThreadEvent))
+            self.assertEqual(event.name, 'request_thread_control')
+            self.assertEqual(event.requested_owner_app_id, 123456789)
+            self.assertEqual(event.metadata, "additional content that the caller wants to set")
+            self.assertEqual(event.timestamp, 1458692752478)
+            self.assertEqual(event.sender_id, '<USER_ID>')
+            self.assertEqual(event.recipient_id, '<PSID>')
+            counter1()
+
+        self.page.handle_webhook(payload)
+        self.assertEquals(1, counter1.call_count)
+
+        counter2 = mock.MagicMock()
+
+        def handler2(event):
+            counter2()
+
+        self.page.handle_webhook(payload, request_thread_control=handler2)
+        self.assertEquals(1, counter2.call_count)
+
+    def test_handle_app_roles(self):
+        payload = """
+                {"object":"page","entry":[{"id":"1691462197845448","time":1472028006107,
+                    "messaging":[{
+                      "recipient":{
+                        "id":"<PSID>"
+                      },
+                      "timestamp":1458692752478,
+                      "app_roles":{
+                        "123456789":["primary_receiver"]
+                      }
+                    }]
+                }]}
+                """
+        counter1 = mock.MagicMock()
+
+        @self.page.handle_app_roles
+        def handler1(event):
+            self.assertTrue(isinstance(event, Event.AppRoleEvent))
+            self.assertEqual(event.name, 'app_roles')
+            self.assertEqual(event.app_roles, {"123456789": ["primary_receiver"]})
+            self.assertEqual(event.timestamp, 1458692752478)
+            self.assertEqual(event.recipient_id, '<PSID>')
+            counter1()
+
+        self.page.handle_webhook(payload)
+        self.assertEquals(1, counter1.call_count)
+
+        counter2 = mock.MagicMock()
+
+        def handler2(event):
+            counter2()
+
+        self.page.handle_webhook(payload, app_roles=handler2)
+        self.assertEquals(1, counter2.call_count)
+
+    def test_handle_policy_enforcement(self):
+        payload = """
+                {"object":"page","entry":[{"id":"1691462197845448","time":1472028006107,
+                    "messaging":[{
+                      "recipient":{
+                        "id":"PAGE_ID"
+                      },
+                      "timestamp":1458692752478,
+                      "policy-enforcement":{
+                        "action":"block",
+                        "reason":"The bot violated our Platform Policies (https://developers.facebook.com/policy/#messengerplatform). Common violations include sending out excessive spammy messages or being non-functional."
+                      }
+                    }]
+                }]}
+                """
+        counter1 = mock.MagicMock()
+
+        @self.page.handle_policy_enforcement
+        def handler1(event):
+            self.assertTrue(isinstance(event, Event.PolicyEnforcementEvent))
+            self.assertEqual(event.name, 'policy_enforcement')
+            self.assertEqual(event.action, 'block')
+            self.assertEqual(event.reason, 'The bot violated our Platform Policies (https://developers.facebook.com/policy/#messengerplatform). Common violations include sending out excessive spammy messages or being non-functional.')
+            self.assertEqual(event.timestamp, 1458692752478)
+            self.assertEqual(event.recipient_id, 'PAGE_ID')
+            counter1()
+
+        self.page.handle_webhook(payload)
+        self.assertEquals(1, counter1.call_count)
+
+        counter2 = mock.MagicMock()
+
+        def handler2(event):
+            counter2()
+
+        self.page.handle_webhook(payload, policy_enforcement=handler2)
+        self.assertEquals(1, counter2.call_count)
+
+    def test_handle_checkout_update(self):
+        payload = """
+                {"object":"page","entry":[{"id":"1691462197845448","time":1472028006107,
+                    "messaging":[{
+                      "sender": {
+                        "id": "<PSID>"
+                      },
+                      "recipient": {
+                        "id": "<PAGE_ID>"
+                      },
+                      "timestamp": 1473204787206,
+                      "checkout_update": {
+                        "payload": "DEVELOPER_DEFINED_PAYLOAD",
+                        "shipping_address": {
+                          "id": 10105655000959552,
+                          "country": "US",
+                          "city": "MENLO PARK",
+                          "street1": "1 Hacker Way",
+                          "street2": "",
+                          "state": "CA",
+                          "postal_code": "94025"
+                        }
+                      }
+                    }]
+                }]}
+                """
+        counter1 = mock.MagicMock()
+
+        @self.page.handle_checkout_update
+        def handler1(event):
+            self.assertTrue(isinstance(event, Event.CheckOutUpdateEvent))
+            self.assertEqual(event.name, 'checkout_update')
+            self.assertEqual(event.payload, 'DEVELOPER_DEFINED_PAYLOAD')
+            self.assertEqual(
+                event.shipping_address,
+                {
+                    "id": 10105655000959552,
+                    "country": "US",
+                    "city": "MENLO PARK",
+                    "street1": "1 Hacker Way",
+                    "street2": "",
+                    "state": "CA",
+                    "postal_code": "94025"
+                })
+            self.assertEqual(event.timestamp, 1473204787206)
+            self.assertEqual(event.sender_id, '<PSID>')
+            self.assertEqual(event.recipient_id, '<PAGE_ID>')
+            counter1()
+
+        self.page.handle_webhook(payload)
+        self.assertEquals(1, counter1.call_count)
+
+        counter2 = mock.MagicMock()
+
+        def handler2(event):
+            counter2()
+
+        self.page.handle_webhook(payload, checkout_update=handler2)
+        self.assertEquals(1, counter2.call_count)
+
+    def test_handle_payment(self):
+        payload = json.dumps({
+            "object": "page","entry": [{"id": "PAGE_ID", "time": 1473208792799,
+                  "messaging": [
+                    {
+                      "recipient": {
+                        "id": "PAGE_ID"
+                      },
+                      "timestamp": 1473208792799,
+                      "sender": {
+                        "id": "USER_ID"
+                      },
+                      "payment": {
+                        "payload": "DEVELOPER_DEFINED_PAYLOAD",
+                        "requested_user_info": {
+                          "shipping_address": {
+                            "street_1": "1 Hacker Way",
+                            "street_2": "",
+                            "city": "MENLO PARK",
+                            "state": "CA",
+                            "country": "US",
+                            "postal_code": "94025"
+                          },
+                          "contact_name": "Peter Chang",
+                          "contact_email": "peter@anemailprovider.com",
+                          "contact_phone": "+15105551234"
+                        },
+                       "payment_credential": {
+                          "provider_type": "stripe",
+                          "charge_id": "ch_18tmdBEoNIH3FPJHa60ep123",
+                          "fb_payment_id": "123456789",
+                        },      
+                        "amount": {
+                          "currency": "USD",
+                          "amount": "29.62"
+                        }, 
+                        "shipping_option_id": "123"
+                      }}]
+                }]}
+        )
+        counter1 = mock.MagicMock()
+
+        @self.page.handle_payment
+        def handler1(event):
+            self.assertTrue(isinstance(event, Event.PaymentEvent))
+            self.assertEqual(event.name, 'payment')
+            self.assertEqual(event.payload, 'DEVELOPER_DEFINED_PAYLOAD')
+            self.assertEqual(
+                event.requested_user_info,
+                {
+                    "shipping_address": {
+                        "street_1": "1 Hacker Way",
+                        "street_2": "",
+                        "city": "MENLO PARK",
+                        "state": "CA",
+                        "country": "US",
+                        "postal_code": "94025"
+                    },
+                    "contact_name": "Peter Chang",
+                    "contact_email": "peter@anemailprovider.com",
+                    "contact_phone": "+15105551234"
+                })
+            self.assertEqual(
+                event.payment_credential,
+                {
+                    "provider_type": "stripe",  # paypal if you are using paypal as provider
+                    "charge_id": "ch_18tmdBEoNIH3FPJHa60ep123",
+                    "fb_payment_id": "123456789",
+                }
+            )
+            self.assertEqual(
+                event.amount,
+                {
+                    "currency": "USD",
+                    "amount": "29.62"
+                }
+            )
+            self.assertEqual(event.shipping_option_id, '123')
+            self.assertEqual(event.timestamp, 1473208792799)
+            self.assertEqual(event.sender_id, 'USER_ID')
+            self.assertEqual(event.recipient_id, 'PAGE_ID')
+            counter1()
+
+        self.page.handle_webhook(payload)
+        self.assertEquals(1, counter1.call_count)
+
+        counter2 = mock.MagicMock()
+
+        def handler2(event):
+            counter2()
+
+        self.page.handle_webhook(payload, payment=handler2)
+        self.assertEquals(1, counter2.call_count)
+
     def test_handle_webhook_postback_button_callback(self):
         payload = """
         {"object":"page","entry":[{"id":"1691462197845448","time":1472028006107,


### PR DESCRIPTION
I suggest __Maintain Event Class separately__
- This separation makes code more suitable for object-oriented.
- This is more efficient way to maintain and expand code for new webhook event
- And modify features in each class efficiently.

With this separation we can clarify what we have to do for a new Event class from the facebook.
Only 3 steps are required
1) Add new event class. 
2) Add new event handler. 
3) Add new logic in event_parser & handle_webhook 
\+ test code

Here is an example of adding a new class.
- target class: messaging_game_plays
- reference: [link](https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_game_plays)
1) step1: Add new event class for messaging_game_plays. --> [GamePlayEvent](https://github.com/conbus/fbmq/compare/master...HwangWonYo:modify_event?expand=1#diff-584f0f0b3eae7b9e51167b5cf3c26ae9R145)
2) step2: Add a event handler for the GamePlayEvent. --> [handle_game_play](https://github.com/conbus/fbmq/compare/master...HwangWonYo:modify_event?expand=1#diff-57774c544495b359737c67999fb541eaR562)
3) step3: Add elif for the game_play handler. --> in [event_parser](https://github.com/conbus/fbmq/compare/master...HwangWonYo:modify_event?expand=1#diff-57774c544495b359737c67999fb541eaR170) & in [hadle_webhook](https://github.com/conbus/fbmq/compare/master...HwangWonYo:modify_event?expand=1#diff-57774c544495b359737c67999fb541eaR285)
